### PR TITLE
Add fixture count assertion to test predictions page

### DIFF
--- a/test-predictions.php
+++ b/test-predictions.php
@@ -81,6 +81,19 @@ input {
     $(document).ready(function () {
         // Fetch data from JSON file
         $.getJSON("json/uefa-euro-2024-fixtures-ro16.json", function (data) {
+            const expectedCount = 8;
+            if (!Array.isArray(data) || data.length !== expectedCount) {
+                const actualCount = Array.isArray(data) ? data.length : 'non-array data';
+                console.error(`Fixture data count mismatch. Expected ${expectedCount}, got ${actualCount}.`);
+                if (!$('#fixtures-alert').length) {
+                    $('#table').before(`
+                        <div id="fixtures-alert" class="alert alert-danger" role="alert">
+                            Test failed: expected ${expectedCount} fixtures, but received ${actualCount}.
+                        </div>
+                    `);
+                }
+                return;
+            }
             let fixture = '';
             let x = 73, y = 74;
 


### PR DESCRIPTION
### Motivation
- Ensure the test predictions page validates that the JSON fixture payload contains the expected number of fixtures (`8`).
- Surface a clear, visible failure when the fixtures file is malformed or changed so the issue is obvious during manual or automated checks.

### Description
- Added a count assertion inside the `$.getJSON` callback in `test-predictions.php` that compares `data.length` against `expectedCount` (`8`).
- If the data is not an array or the length doesn't match, the code logs a clear error with `console.error` and inserts a Bootstrap alert above the `#table` element with id `fixtures-alert`.
- The handler returns early on mismatch to prevent rendering incorrect rows and otherwise proceeds with the existing rendering flow as before.
- All changes are contained in `test-predictions.php` near the "Fetch data from JSON file" block.

### Testing
- No automated tests were run for this change.
- The change was committed to the repository and the modified file is `test-predictions.php`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69603fd20b048324b292512857e9ad3b)