### PR TITLE
Guard progress bar updates when missing

### DIFF
--- a/js/multi-step-form.js
+++ b/js/multi-step-form.js
@@ -57,6 +57,10 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   function updateProgressbar() {
+      if (!progress || progressSteps.length === 0) {
+          return;
+      }
+
       progressSteps.forEach((progressStep, idx) => {
           if (idx < currentStep + 1) {
               progressStep.classList.add("progress-step-active");


### PR DESCRIPTION
### Motivation
- Prevent a runtime `TypeError` on pages that don't include the progress bar by making `updateProgressbar()` a no-op when required DOM nodes are absent.

### Description
- Add an early return in `updateProgressbar()` that checks `if (!progress || progressSteps.length === 0)` and returns immediately to avoid accessing `progress.style` when `#progress` or `.progress-step` elements are missing.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69694b64a27883249d9508912cc3a3f1)