### PR TITLE
Add pros/cons insights to About cards and add World Cup 2026 card

### DIFF
--- a/about.php
+++ b/about.php
@@ -46,6 +46,16 @@ include "php/navigation.php";
 						<h5 class="card-title">The spreadsheet era begins</h5>
 						<p class="card-text">The first origins of Hendy's Hunches - complete with no game name and no supporting website! It was a very monotonous process which consisted simply of sending friends a basic spreadsheet template, having them input their scores for each game and return it to me before the competition began. It was flaky at best although it did seem to be well perceived by those who had taken part. I'd spend a couple of hours a day trauling through each player's spreadsheet and manually calculating points before sending a daily email update of a table with scores and rankings. Despite the tedious effort, it left me thinking that it would be great to repeat the event again some time in the future.</p>
 					</div>
+					<ul class="about-insights list-unstyled">
+						<li class="about-insights__item about-insights__item--pro">
+							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+							<span>Kick-started the tradition with plenty of banter.</span>
+						</li>
+						<li class="about-insights__item about-insights__item--con">
+							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+							<span>Manual score updates took hours of effort.</span>
+						</li>
+					</ul>
 					<ul class="about-podium list-unstyled">
 						<li class="about-podium__item">
 							<span class="about-podium__rank">1st</span>
@@ -71,6 +81,16 @@ include "php/navigation.php";
 						<h5 class="card-title">The online leap</h5>
 						<p class="card-text">In need of dusting off my programming skills, I thought it would be good to replicate the fun of the game for 2006 - only bigger and better. The hardest things I had to decide on were 1) what format a site would take for it (look and feel), 2) what each player could expect to do (on a basic level), and 3) a points mechanism that would be fair and present good competition. Users were pointed to an online form which they completed all predictions (only for the group stages) in one go. Then, after each game I would enter results into a page and points were given automatically based on players' predictions against a result. A table of rankings kept everyone's points tally. Not too pretty but efficient.</p>
 					</div>
+					<ul class="about-insights list-unstyled">
+						<li class="about-insights__item about-insights__item--pro">
+							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+							<span>Online submissions made joining the game effortless.</span>
+						</li>
+						<li class="about-insights__item about-insights__item--con">
+							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+							<span>Predictions were limited to the group stages only.</span>
+						</li>
+					</ul>
 					<ul class="about-podium list-unstyled">
 						<li class="about-podium__item">
 							<span class="about-podium__rank">1st</span>
@@ -96,6 +116,16 @@ include "php/navigation.php";
 						<h5 class="card-title">Feature-rich fan favorite</h5>
 						<p class="card-text">Determined to build on the success of the World Cup 2014 version, feedback and positive suggestions has seen significant improvements. Not all changes are widely visible as a lot of the 'under the hood' mechanics have been reworked. Some of the most major improvements include a statistics dashboard, improved rankings system, better in-game communication methods and the ability to make changes to a prediction close up until its match kick-off. All of this and more now sits behind a new and secure login facility. There is always room for improvement so I'm happy to take any comments people have for what could be in a future version. Who will finish in the top places?</p>
 					</div>
+					<ul class="about-insights list-unstyled">
+						<li class="about-insights__item about-insights__item--pro">
+							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+							<span>Richer stats and flexible edits kept everyone engaged.</span>
+						</li>
+						<li class="about-insights__item about-insights__item--con">
+							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+							<span>More features meant more upkeep behind the scenes.</span>
+						</li>
+					</ul>
 					<ul class="about-podium list-unstyled">
 						<li class="about-podium__item">
 							<span class="about-podium__rank">1st</span>
@@ -121,6 +151,16 @@ include "php/navigation.php";
 						<h5 class="card-title">The community grows</h5>
 						<p class="card-text">More players, tighter competition, and a thriving scoreboard made this edition one of the most competitive yet.</p>
 					</div>
+					<ul class="about-insights list-unstyled">
+						<li class="about-insights__item about-insights__item--pro">
+							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+							<span>The growing community brought nonstop match chatter.</span>
+						</li>
+						<li class="about-insights__item about-insights__item--con">
+							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+							<span>Points were harder to come by with so many sharp predictors.</span>
+						</li>
+					</ul>
 					<ul class="about-podium list-unstyled">
 						<li class="about-podium__item">
 							<span class="about-podium__rank">1st</span>
@@ -146,6 +186,16 @@ include "php/navigation.php";
 						<h5 class="card-title">Global spotlight</h5>
 						<p class="card-text">A fast-paced tournament where every last-minute goal kept the predictions on edge.</p>
 					</div>
+					<ul class="about-insights list-unstyled">
+						<li class="about-insights__item about-insights__item--pro">
+							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+							<span>Rapid updates kept the leaderboard feeling alive.</span>
+						</li>
+						<li class="about-insights__item about-insights__item--con">
+							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+							<span>Quick turnarounds left little time for last tweaks.</span>
+						</li>
+					</ul>
 					<ul class="about-podium list-unstyled">
 						<li class="about-podium__item">
 							<span class="about-podium__rank">1st</span>
@@ -171,18 +221,63 @@ include "php/navigation.php";
 						<h5 class="card-title">Next chapter loading</h5>
 						<p class="card-text">The latest edition is underway. Who will earn the next bragging rights?</p>
 					</div>
+					<ul class="about-insights list-unstyled">
+						<li class="about-insights__item about-insights__item--pro">
+							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+							<span>Fresh format ideas kept predictions feeling new again.</span>
+						</li>
+						<li class="about-insights__item about-insights__item--con">
+							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+							<span>Still fine-tuning the scoring rules for next time.</span>
+						</li>
+					</ul>
 					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item about-podium__item--pending">
+						<li class="about-podium__item">
 							<span class="about-podium__rank">1st</span>
 							<span class="about-podium__name">Jonathan Lamley</span>
 						</li>
-						<li class="about-podium__item about-podium__item--pending">
+						<li class="about-podium__item">
 							<span class="about-podium__rank">2nd</span>
 							<span class="about-podium__name">Paul Hendrick</span>
 						</li>
-						<li class="about-podium__item about-podium__item--pending">
+						<li class="about-podium__item">
 							<span class="about-podium__rank">3rd</span>
 							<span class="about-podium__name">David Holmes</span>
+						</li>
+					</ul>
+				</div>
+			</div>
+
+			<div class="col-12 col-md-6 col-lg-4">
+				<div class="card about-card h-100">
+					<img src="img/hh-logo-2024.jpg" alt="FIFA World Cup 2026 Game Image" class="card-img-top">
+					<div class="card-body">
+						<span class="about-season">FIFA World Cup 2026</span>
+						<h5 class="card-title">The next horizon</h5>
+						<p class="card-text">Planning is underway for the biggest tournament yet. Expect more teams, more matches, and more chances to climb the leaderboard.</p>
+					</div>
+					<ul class="about-insights list-unstyled">
+						<li class="about-insights__item about-insights__item--pro">
+							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+							<span>Expanded format should bring a wider mix of matchups.</span>
+						</li>
+						<li class="about-insights__item about-insights__item--con">
+							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+							<span>Final schedule and scoring tweaks are still TBC.</span>
+						</li>
+					</ul>
+					<ul class="about-podium list-unstyled">
+						<li class="about-podium__item about-podium__item--pending">
+							<span class="about-podium__rank">1st</span>
+							<span class="about-podium__name">Pending</span>
+						</li>
+						<li class="about-podium__item about-podium__item--pending">
+							<span class="about-podium__rank">2nd</span>
+							<span class="about-podium__name">TBC</span>
+						</li>
+						<li class="about-podium__item about-podium__item--pending">
+							<span class="about-podium__rank">3rd</span>
+							<span class="about-podium__name">TBC</span>
 						</li>
 					</ul>
 				</div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -254,6 +254,34 @@
     line-height: 1.55;
   }
 
+  .about-insights {
+    display: grid;
+    gap: 8px;
+    margin: 0 24px 16px;
+    padding: 0;
+  }
+
+  .about-insights__item {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    font-size: 0.9rem;
+    color: #4b5563;
+  }
+
+  .about-insights__item i {
+    font-size: 1rem;
+    margin-top: 2px;
+  }
+
+  .about-insights__item--pro i {
+    color: #16a34a;
+  }
+
+  .about-insights__item--con i {
+    color: #dc2626;
+  }
+
   .about-podium {
     display: grid;
     gap: 10px;


### PR DESCRIPTION
### Motivation
- Surface a short pros/cons summary for each historical card to give quick insights between the description and winners. 
- Reflect the updated Euro 2024 winners (remove pending styling) and add a placeholder card for FIFA World Cup 2026 showing pending/TBC winners. 

### Description
- Updated `about.php` to insert an `about-insights` pros/cons subsection into each timeline card (WC2006, WC2014, Euro2016, WC2018, WC2022, Euro2024). 
- Removed `about-podium__item--pending` classes from the Euro 2024 podium items so winners are shown as final. 
- Added a new World Cup 2026 card (uses `img/hh-logo-2024.jpg` as a placeholder image) with pending/TBC podium items. 
- Added styling for the new `about-insights` list and icon colors in `css/styles.css` (green plus and red dash via existing Bootstrap Icons classes). 

### Testing
- Launched a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/hendys-hunches`, which started successfully. 
- Captured a full-page screenshot of `/about.php` using a Playwright script, which completed and produced an artifact (visual verification). 
- No automated unit tests were applicable for these content/UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696956cd09008324add2777a0d19d8f6)