### PR TITLE
Add read-more/read-less truncation to About page descriptions

### DIFF
--- a/about.php
+++ b/about.php
@@ -290,5 +290,44 @@ include "php/navigation.php";
   </div>
 </main>
 
+<script>
+	document.addEventListener('DOMContentLoaded', () => {
+		const wordLimit = 28;
+		const descriptions = document.querySelectorAll('.about-card .card-text');
+
+		descriptions.forEach((description) => {
+			const fullText = description.textContent.trim();
+			const words = fullText.split(/\s+/);
+
+			if (words.length <= wordLimit) {
+				return;
+			}
+
+			const shortText = `${words.slice(0, wordLimit).join(' ')}...`;
+			const toggle = document.createElement('button');
+
+			toggle.type = 'button';
+			toggle.className = 'about-readmore btn btn-link p-0';
+			toggle.textContent = 'read more';
+			toggle.setAttribute('aria-expanded', 'false');
+
+			const updateText = (expanded) => {
+				description.classList.toggle('is-expanded', expanded);
+				description.textContent = expanded ? fullText : shortText;
+				description.append(' ');
+				description.appendChild(toggle);
+				toggle.textContent = expanded ? 'read less' : 'read more';
+				toggle.setAttribute('aria-expanded', expanded.toString());
+			};
+
+			toggle.addEventListener('click', () => {
+				updateText(!description.classList.contains('is-expanded'));
+			});
+
+			updateText(false);
+		});
+	});
+</script>
+
 <!-- Footer -->
 <?php include "php/footer.php" ?>

--- a/css/styles.css
+++ b/css/styles.css
@@ -254,6 +254,19 @@
     line-height: 1.55;
   }
 
+  .about-card .about-readmore {
+    font-size: inherit;
+    font-weight: 600;
+    color: #4154f1;
+    text-decoration: none;
+    vertical-align: baseline;
+  }
+
+  .about-card .about-readmore:hover,
+  .about-card .about-readmore:focus {
+    text-decoration: underline;
+  }
+
   .about-insights {
     display: grid;
     gap: 8px;


### PR DESCRIPTION
### Motivation
- Long historical descriptions on the About cards made cards uneven, so client-side truncation with an expand/collapse control was added to keep the layout compact and consistent.

### Description
- Added a small client-side script in `about.php` that truncates each `.about-card .card-text` to 28 words and injects a `read more` / `read less` toggle button while preserving the full text when expanded.
- The toggle uses a `button` with `aria-expanded` state and an `is-expanded` class to manage expanded/collapsed state without changing server-side markup.
- Added styles in `css/styles.css` for the `.about-readmore` control to match the About card typography and hover states.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t .`, which started successfully.
- Attempted to capture a visual regression screenshot using Playwright against `/about.php`, but the headless Chromium process crashed (SIGSEGV) and the screenshot attempt failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69695cb9219c8324b86e1678bfb27570)