### PR TITLE
Update typography: Montserrat for body and Playfair Display for headings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -6,7 +6,7 @@
 * License: https://bootstrapmade.com/license/
 */
 
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&family=Playfair+Display:ital,wght@0,400..900;1,400..900&display=swap');
 
 /*--------------------------------------------------------------
 # General
@@ -21,7 +21,7 @@
     background-position: center; /* Center the image */
     background-repeat: no-repeat; /* Do not repeat the image */
     background-size: cover; /* Resize the background image to cover the entire container */
-    font-family: 'Noto Sans';
+    font-family: 'Montserrat', sans-serif;
   }
 
   a {
@@ -41,7 +41,8 @@
   h5,
   h6 {
     /* font-family: "Nunito", sans-serif; */
-    font-family: 'Noto Sans';
+    font-family: 'Playfair Display', serif;
+    font-weight: 500;
   }
   
   /*--------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Standardise site-wide typography to match updated brand style by using Montserrat for main body text and Playfair Display Medium for all headings.

### Description
- Replace the Google Fonts import in `css/styles.css` to include `Montserrat` and `Playfair Display`.
- Set `body` font-family to `'Montserrat', sans-serif` in `css/styles.css`.
- Set `h1`–`h6` font-family to `'Playfair Display', serif` and apply `font-weight: 500` in `css/styles.css`.

### Testing
- Started a local PHP development server with `php -S 0.0.0.0:8000 -t .` and ran a Playwright script to render `index.php` and capture a screenshot to `artifacts/typography-update.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b937169ec8324bcdc6cee3c2f42c3)