### PR TITLE
Redesign About page to horizontal cards and update purple accent to #284b63

### DIFF
--- a/about.php
+++ b/about.php
@@ -38,248 +38,318 @@ include "php/navigation.php";
 		</div>
 
 		<div class="row g-4 about-grid">
-			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card about-card h-100">
-					<img src="img/wc2006-ss.png" alt="World Cup 2006 Game Image" class="card-img-top">
-					<div class="card-body">
-						<span class="about-season">FIFA World Cup 2006</span>
-						<h5 class="card-title">The spreadsheet era begins</h5>
-						<p class="card-text">Hendy’s Hunches began as a very simple idea, long before there was a name or website. Friends submitted their predictions using a shared spreadsheet, with scores calculated and updated manually each day. It was far from slick, but the positive response showed there was something worth returning to in the future.</p>
+			<div class="col-12">
+				<div class="card about-card about-card--horizontal h-100">
+					<div class="about-card__layout">
+						<div class="about-card__media">
+							<img src="img/wc2006-ss.png" alt="World Cup 2006 Game Image" class="about-card__image">
+							<ul class="about-podium list-unstyled">
+								<li class="about-podium__item">
+									<span class="about-podium__rank">1st</span>
+									<span class="about-podium__name">Steven Lough, James Henderson</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">2nd</span>
+									<span class="about-podium__name">Kirsty Yarnold</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">3rd</span>
+									<span class="about-podium__name">Julien Alégre, Andrew Lough</span>
+								</li>
+							</ul>
+						</div>
+						<div class="about-card__content">
+							<div class="card-body">
+								<span class="about-season">FIFA World Cup 2006</span>
+								<h5 class="card-title">The spreadsheet era begins</h5>
+								<p class="card-text">Hendy’s Hunches began as a very simple idea, long before there was a name or website. Friends submitted their predictions using a shared spreadsheet, with scores calculated and updated manually each day. It was far from slick, but the positive response showed there was something worth returning to in the future.</p>
+							</div>
+							<ul class="about-insights list-unstyled">
+								<li class="about-insights__item about-insights__item--pro">
+									<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+									<span>Kick-started the tradition with plenty of banter.</span>
+								</li>
+								<li class="about-insights__item about-insights__item--con">
+									<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+									<span>Manual score updates took hours of effort.</span>
+								</li>
+							</ul>
+							<div class="about-charity">
+								<h6 class="about-charity__title">Charity spotlight</h6>
+								<p class="about-charity__text">Placeholder for the chosen charity partner, impact notes, and donation highlights.</p>
+							</div>
+						</div>
 					</div>
-					<ul class="about-insights list-unstyled">
-						<li class="about-insights__item about-insights__item--pro">
-							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
-							<span>Kick-started the tradition with plenty of banter.</span>
-						</li>
-						<li class="about-insights__item about-insights__item--con">
-							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
-							<span>Manual score updates took hours of effort.</span>
-						</li>
-					</ul>
-					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item">
-							<span class="about-podium__rank">1st</span>
-							<span class="about-podium__name">Steven Lough, James Henderson</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">2nd</span>
-							<span class="about-podium__name">Kirsty Yarnold</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">3rd</span>
-							<span class="about-podium__name">Julien Alégre, Andrew Lough</span>
-						</li>
-					</ul>
 				</div>
 			</div>
 
-			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card about-card h-100">
-					<img src="img/wc2014-site.png" alt="World Cup 2014 Game Image" class="card-img-top">
-					<div class="card-body">
-						<span class="about-season">FIFA World Cup 2014</span>
-						<h5 class="card-title">The online leap</h5>
-						<p class="card-text">Looking to revive the game and sharpen my programming skills, I rebuilt Hendy’s Hunches as a basic web experience. Players submitted all their group-stage predictions via an online form, with results and points calculated automatically after each match. While visually simple, it introduced fair scoring, live rankings, and a much smoother experience.</p>
+			<div class="col-12">
+				<div class="card about-card about-card--horizontal h-100">
+					<div class="about-card__layout">
+						<div class="about-card__media">
+							<img src="img/wc2014-site.png" alt="World Cup 2014 Game Image" class="about-card__image">
+							<ul class="about-podium list-unstyled">
+								<li class="about-podium__item">
+									<span class="about-podium__rank">1st</span>
+									<span class="about-podium__name">Andrew Booth</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">2nd</span>
+									<span class="about-podium__name">Nigel Plant</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">3rd</span>
+									<span class="about-podium__name">Luke Fecowycz</span>
+								</li>
+							</ul>
+						</div>
+						<div class="about-card__content">
+							<div class="card-body">
+								<span class="about-season">FIFA World Cup 2014</span>
+								<h5 class="card-title">The online leap</h5>
+								<p class="card-text">Looking to revive the game and sharpen my programming skills, I rebuilt Hendy’s Hunches as a basic web experience. Players submitted all their group-stage predictions via an online form, with results and points calculated automatically after each match. While visually simple, it introduced fair scoring, live rankings, and a much smoother experience.</p>
+							</div>
+							<ul class="about-insights list-unstyled">
+								<li class="about-insights__item about-insights__item--pro">
+									<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+									<span>Online submissions made joining the game effortless.</span>
+								</li>
+								<li class="about-insights__item about-insights__item--con">
+									<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+									<span>Predictions were limited to the group stages only.</span>
+								</li>
+							</ul>
+							<div class="about-charity">
+								<h6 class="about-charity__title">Charity spotlight</h6>
+								<p class="about-charity__text">Placeholder for the chosen charity partner, impact notes, and donation highlights.</p>
+							</div>
+						</div>
 					</div>
-					<ul class="about-insights list-unstyled">
-						<li class="about-insights__item about-insights__item--pro">
-							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
-							<span>Online submissions made joining the game effortless.</span>
-						</li>
-						<li class="about-insights__item about-insights__item--con">
-							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
-							<span>Predictions were limited to the group stages only.</span>
-						</li>
-					</ul>
-					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item">
-							<span class="about-podium__rank">1st</span>
-							<span class="about-podium__name">Andrew Booth</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">2nd</span>
-							<span class="about-podium__name">Nigel Plant</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">3rd</span>
-							<span class="about-podium__name">Luke Fecowycz</span>
-						</li>
-					</ul>
 				</div>
 			</div>
 
-			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card about-card h-100">
-					<img src="img/euro2016-site-v3.png" alt="Euro 2016 Game Image" class="card-img-top">
-					<div class="card-body">
-						<span class="about-season">UEFA Euro 2016</span>
-						<h5 class="card-title">Feature-rich fan favorite</h5>
-						<p class="card-text">Building on the success of the 2014 version, this iteration focused on refinement and depth. Behind the scenes, core systems were reworked to support features like detailed statistics, improved rankings, better communication, and late prediction changes right up to kick-off. All of this now sits within a secure login system, with plenty of scope for future enhancements.</p>
+			<div class="col-12">
+				<div class="card about-card about-card--horizontal h-100">
+					<div class="about-card__layout">
+						<div class="about-card__media">
+							<img src="img/euro2016-site-v3.png" alt="Euro 2016 Game Image" class="about-card__image">
+							<ul class="about-podium list-unstyled">
+								<li class="about-podium__item">
+									<span class="about-podium__rank">1st</span>
+									<span class="about-podium__name">Jonathan Lamley</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">2nd</span>
+									<span class="about-podium__name">Sam McGuigan</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">3rd</span>
+									<span class="about-podium__name">Steve Butt, Kirsty Yarnold</span>
+								</li>
+							</ul>
+						</div>
+						<div class="about-card__content">
+							<div class="card-body">
+								<span class="about-season">UEFA Euro 2016</span>
+								<h5 class="card-title">Feature-rich fan favorite</h5>
+								<p class="card-text">Building on the success of the 2014 version, this iteration focused on refinement and depth. Behind the scenes, core systems were reworked to support features like detailed statistics, improved rankings, better communication, and late prediction changes right up to kick-off. All of this now sits within a secure login system, with plenty of scope for future enhancements.</p>
+							</div>
+							<ul class="about-insights list-unstyled">
+								<li class="about-insights__item about-insights__item--pro">
+									<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+									<span>Richer stats and flexible edits kept everyone engaged.</span>
+								</li>
+								<li class="about-insights__item about-insights__item--con">
+									<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+									<span>More features meant more upkeep behind the scenes.</span>
+								</li>
+							</ul>
+							<div class="about-charity">
+								<h6 class="about-charity__title">Charity spotlight</h6>
+								<p class="about-charity__text">Placeholder for the chosen charity partner, impact notes, and donation highlights.</p>
+							</div>
+						</div>
 					</div>
-					<ul class="about-insights list-unstyled">
-						<li class="about-insights__item about-insights__item--pro">
-							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
-							<span>Richer stats and flexible edits kept everyone engaged.</span>
-						</li>
-						<li class="about-insights__item about-insights__item--con">
-							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
-							<span>More features meant more upkeep behind the scenes.</span>
-						</li>
-					</ul>
-					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item">
-							<span class="about-podium__rank">1st</span>
-							<span class="about-podium__name">Jonathan Lamley</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">2nd</span>
-							<span class="about-podium__name">Sam McGuigan</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">3rd</span>
-							<span class="about-podium__name">Steve Butt, Kirsty Yarnold</span>
-						</li>
-					</ul>
 				</div>
 			</div>
 
-			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card about-card h-100">
-					<img src="img/hh-logo-2024.jpg" alt="FIFA World Cup 2018 Game Image" class="card-img-top">
-					<div class="card-body">
-						<span class="about-season">FIFA World Cup 2018</span>
-						<h5 class="card-title">The community grows</h5>
-						<p class="card-text">More players, tighter competition, and a thriving scoreboard made this edition one of the most competitive yet.</p>
+			<div class="col-12">
+				<div class="card about-card about-card--horizontal h-100">
+					<div class="about-card__layout">
+						<div class="about-card__media">
+							<img src="img/hh-logo-2024.jpg" alt="FIFA World Cup 2018 Game Image" class="about-card__image">
+							<ul class="about-podium list-unstyled">
+								<li class="about-podium__item">
+									<span class="about-podium__rank">1st</span>
+									<span class="about-podium__name">Nick Chandler</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">2nd</span>
+									<span class="about-podium__name">Snigdha Dutta, Sonia Fernandez</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">3rd</span>
+									<span class="about-podium__name">Daniel Waite</span>
+								</li>
+							</ul>
+						</div>
+						<div class="about-card__content">
+							<div class="card-body">
+								<span class="about-season">FIFA World Cup 2018</span>
+								<h5 class="card-title">The community grows</h5>
+								<p class="card-text">More players, tighter competition, and a thriving scoreboard made this edition one of the most competitive yet.</p>
+							</div>
+							<ul class="about-insights list-unstyled">
+								<li class="about-insights__item about-insights__item--pro">
+									<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+									<span>The growing community brought nonstop match chatter.</span>
+								</li>
+								<li class="about-insights__item about-insights__item--con">
+									<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+									<span>Points were harder to come by with so many sharp predictors.</span>
+								</li>
+							</ul>
+							<div class="about-charity">
+								<h6 class="about-charity__title">Charity spotlight</h6>
+								<p class="about-charity__text">Placeholder for the chosen charity partner, impact notes, and donation highlights.</p>
+							</div>
+						</div>
 					</div>
-					<ul class="about-insights list-unstyled">
-						<li class="about-insights__item about-insights__item--pro">
-							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
-							<span>The growing community brought nonstop match chatter.</span>
-						</li>
-						<li class="about-insights__item about-insights__item--con">
-							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
-							<span>Points were harder to come by with so many sharp predictors.</span>
-						</li>
-					</ul>
-					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item">
-							<span class="about-podium__rank">1st</span>
-							<span class="about-podium__name">Nick Chandler</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">2nd</span>
-							<span class="about-podium__name">Snigdha Dutta, Sonia Fernandez</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">3rd</span>
-							<span class="about-podium__name">Daniel Waite</span>
-						</li>
-					</ul>
 				</div>
 			</div>
 
-			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card about-card h-100">
-					<img src="img/qatar-2022-logo.png" alt="FIFA World Cup 2022 Game Image" class="card-img-top">
-					<div class="card-body">
-						<span class="about-season">FIFA World Cup 2022</span>
-						<h5 class="card-title">Global spotlight</h5>
-						<p class="card-text">A fast-paced tournament where every last-minute goal kept the predictions on edge.</p>
+			<div class="col-12">
+				<div class="card about-card about-card--horizontal h-100">
+					<div class="about-card__layout">
+						<div class="about-card__media">
+							<img src="img/qatar-2022-logo.png" alt="FIFA World Cup 2022 Game Image" class="about-card__image">
+							<ul class="about-podium list-unstyled">
+								<li class="about-podium__item">
+									<span class="about-podium__rank">1st</span>
+									<span class="about-podium__name">Chloe McCandlish</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">2nd</span>
+									<span class="about-podium__name">Howard Kilbourn</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">3rd</span>
+									<span class="about-podium__name">Andrew Lough</span>
+								</li>
+							</ul>
+						</div>
+						<div class="about-card__content">
+							<div class="card-body">
+								<span class="about-season">FIFA World Cup 2022</span>
+								<h5 class="card-title">Global spotlight</h5>
+								<p class="card-text">A fast-paced tournament where every last-minute goal kept the predictions on edge.</p>
+							</div>
+							<ul class="about-insights list-unstyled">
+								<li class="about-insights__item about-insights__item--pro">
+									<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+									<span>Rapid updates kept the leaderboard feeling alive.</span>
+								</li>
+								<li class="about-insights__item about-insights__item--con">
+									<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+									<span>Quick turnarounds left little time for last tweaks.</span>
+								</li>
+							</ul>
+							<div class="about-charity">
+								<h6 class="about-charity__title">Charity spotlight</h6>
+								<p class="about-charity__text">Placeholder for the chosen charity partner, impact notes, and donation highlights.</p>
+							</div>
+						</div>
 					</div>
-					<ul class="about-insights list-unstyled">
-						<li class="about-insights__item about-insights__item--pro">
-							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
-							<span>Rapid updates kept the leaderboard feeling alive.</span>
-						</li>
-						<li class="about-insights__item about-insights__item--con">
-							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
-							<span>Quick turnarounds left little time for last tweaks.</span>
-						</li>
-					</ul>
-					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item">
-							<span class="about-podium__rank">1st</span>
-							<span class="about-podium__name">Chloe McCandlish</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">2nd</span>
-							<span class="about-podium__name">Howard Kilbourn</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">3rd</span>
-							<span class="about-podium__name">Andrew Lough</span>
-						</li>
-					</ul>
 				</div>
 			</div>
 
-			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card about-card h-100">
-					<img src="img/germany-2024-logo-md.png" alt="UEFA Euro 2024 Game Image" class="card-img-top">
-					<div class="card-body">
-						<span class="about-season">UEFA Euro 2024</span>
-						<h5 class="card-title">Next chapter loading</h5>
-						<p class="card-text">The latest edition is underway. Who will earn the next bragging rights?</p>
+			<div class="col-12">
+				<div class="card about-card about-card--horizontal h-100">
+					<div class="about-card__layout">
+						<div class="about-card__media">
+							<img src="img/germany-2024-logo-md.png" alt="UEFA Euro 2024 Game Image" class="about-card__image">
+							<ul class="about-podium list-unstyled">
+								<li class="about-podium__item">
+									<span class="about-podium__rank">1st</span>
+									<span class="about-podium__name">Jonathan Lamley</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">2nd</span>
+									<span class="about-podium__name">Paul Hendrick</span>
+								</li>
+								<li class="about-podium__item">
+									<span class="about-podium__rank">3rd</span>
+									<span class="about-podium__name">David Holmes</span>
+								</li>
+							</ul>
+						</div>
+						<div class="about-card__content">
+							<div class="card-body">
+								<span class="about-season">UEFA Euro 2024</span>
+								<h5 class="card-title">Next chapter loading</h5>
+								<p class="card-text">The latest edition is underway. Who will earn the next bragging rights?</p>
+							</div>
+							<ul class="about-insights list-unstyled">
+								<li class="about-insights__item about-insights__item--pro">
+									<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+									<span>Fresh format ideas kept predictions feeling new again.</span>
+								</li>
+								<li class="about-insights__item about-insights__item--con">
+									<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+									<span>Still fine-tuning the scoring rules for next time.</span>
+								</li>
+							</ul>
+							<div class="about-charity">
+								<h6 class="about-charity__title">Charity spotlight</h6>
+								<p class="about-charity__text">Placeholder for the chosen charity partner, impact notes, and donation highlights.</p>
+							</div>
+						</div>
 					</div>
-					<ul class="about-insights list-unstyled">
-						<li class="about-insights__item about-insights__item--pro">
-							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
-							<span>Fresh format ideas kept predictions feeling new again.</span>
-						</li>
-						<li class="about-insights__item about-insights__item--con">
-							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
-							<span>Still fine-tuning the scoring rules for next time.</span>
-						</li>
-					</ul>
-					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item">
-							<span class="about-podium__rank">1st</span>
-							<span class="about-podium__name">Jonathan Lamley</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">2nd</span>
-							<span class="about-podium__name">Paul Hendrick</span>
-						</li>
-						<li class="about-podium__item">
-							<span class="about-podium__rank">3rd</span>
-							<span class="about-podium__name">David Holmes</span>
-						</li>
-					</ul>
 				</div>
 			</div>
 
-			<div class="col-12 col-md-6 col-lg-4">
-				<div class="card about-card h-100">
-					<img src="img/hh-logo-2024.jpg" alt="FIFA World Cup 2026 Game Image" class="card-img-top">
-					<div class="card-body">
-						<span class="about-season">FIFA World Cup 2026</span>
-						<h5 class="card-title">The next horizon</h5>
-						<p class="card-text">Planning is underway for the biggest tournament yet. Expect more teams, more matches, and more chances to climb the leaderboard.</p>
+			<div class="col-12">
+				<div class="card about-card about-card--horizontal h-100">
+					<div class="about-card__layout">
+						<div class="about-card__media">
+							<img src="img/hh-logo-2024.jpg" alt="FIFA World Cup 2026 Game Image" class="about-card__image">
+							<ul class="about-podium list-unstyled">
+								<li class="about-podium__item about-podium__item--pending">
+									<span class="about-podium__rank">1st</span>
+									<span class="about-podium__name">Pending</span>
+								</li>
+								<li class="about-podium__item about-podium__item--pending">
+									<span class="about-podium__rank">2nd</span>
+									<span class="about-podium__name">TBC</span>
+								</li>
+								<li class="about-podium__item about-podium__item--pending">
+									<span class="about-podium__rank">3rd</span>
+									<span class="about-podium__name">TBC</span>
+								</li>
+							</ul>
+						</div>
+						<div class="about-card__content">
+							<div class="card-body">
+								<span class="about-season">FIFA World Cup 2026</span>
+								<h5 class="card-title">The next horizon</h5>
+								<p class="card-text">Planning is underway for the biggest tournament yet. Expect more teams, more matches, and more chances to climb the leaderboard.</p>
+							</div>
+							<ul class="about-insights list-unstyled">
+								<li class="about-insights__item about-insights__item--pro">
+									<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
+									<span>Expanded format should bring a wider mix of matchups.</span>
+								</li>
+								<li class="about-insights__item about-insights__item--con">
+									<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
+									<span>Final schedule and scoring tweaks are still TBC.</span>
+								</li>
+							</ul>
+							<div class="about-charity">
+								<h6 class="about-charity__title">Charity spotlight</h6>
+								<p class="about-charity__text">Placeholder for the chosen charity partner, impact notes, and donation highlights.</p>
+							</div>
+						</div>
 					</div>
-					<ul class="about-insights list-unstyled">
-						<li class="about-insights__item about-insights__item--pro">
-							<i class="bi bi-plus-circle-fill" aria-hidden="true"></i>
-							<span>Expanded format should bring a wider mix of matchups.</span>
-						</li>
-						<li class="about-insights__item about-insights__item--con">
-							<i class="bi bi-dash-circle-fill" aria-hidden="true"></i>
-							<span>Final schedule and scoring tweaks are still TBC.</span>
-						</li>
-					</ul>
-					<ul class="about-podium list-unstyled">
-						<li class="about-podium__item about-podium__item--pending">
-							<span class="about-podium__rank">1st</span>
-							<span class="about-podium__name">Pending</span>
-						</li>
-						<li class="about-podium__item about-podium__item--pending">
-							<span class="about-podium__rank">2nd</span>
-							<span class="about-podium__name">TBC</span>
-						</li>
-						<li class="about-podium__item about-podium__item--pending">
-							<span class="about-podium__rank">3rd</span>
-							<span class="about-podium__name">TBC</span>
-						</li>
-					</ul>
 				</div>
 			</div>
 		</div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -178,7 +178,7 @@
 
   .about-hero {
     border-radius: 20px;
-    background: linear-gradient(120deg, rgba(65, 84, 241, 0.12), rgba(33, 37, 41, 0.03));
+    background: linear-gradient(120deg, rgba(40, 75, 99, 0.16), rgba(33, 37, 41, 0.03));
     box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
   }
 
@@ -194,7 +194,7 @@
     font-weight: 700;
     letter-spacing: 0.12em;
     text-transform: uppercase;
-    color: #4154f1;
+    color: #284b63;
   }
 
   .about-headline {
@@ -217,16 +217,38 @@
     transition: transform 0.2s ease, box-shadow 0.2s ease;
   }
 
+  .about-card--horizontal {
+    overflow: hidden;
+  }
+
+  .about-card__layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+  }
+
+  .about-card__media {
+    display: flex;
+    flex-direction: column;
+    background: #f8fafc;
+  }
+
+  .about-card__image {
+    width: 100%;
+    height: 240px;
+    object-fit: cover;
+    background: #f5f7fb;
+  }
+
+  .about-card__content {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+  }
+
   .about-card:hover {
     transform: translateY(-4px);
     box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
-  }
-
-  .about-card .card-img-top {
-    height: 200px;
-    width: 100%;
-    object-fit: cover;
-    background: #f5f7fb;
   }
 
   .about-card .card-body {
@@ -258,7 +280,7 @@
   .about-card .about-readmore {
     font-size: inherit;
     font-weight: 600;
-    color: #4154f1;
+    color: #284b63;
     text-decoration: none;
     vertical-align: baseline;
   }
@@ -300,9 +322,9 @@
     display: grid;
     gap: 10px;
     margin: 0;
-    padding: 16px 24px 24px;
-    background: #f8fafc;
-    border-top: 1px solid #e5e7eb;
+    padding: 16px;
+    background: #f1f5f9;
+    border-top: 1px solid #e2e8f0;
   }
 
   .about-podium__item {
@@ -324,7 +346,7 @@
     font-size: 0.8rem;
     font-weight: 700;
     color: #ffffff;
-    background: linear-gradient(135deg, #4154f1, #7c3aed);
+    background: linear-gradient(135deg, #284b63, #3c6a8a);
   }
 
   .about-podium__name {
@@ -334,13 +356,37 @@
   }
 
   .about-podium__item--pending {
-    background: #eef2ff;
+    background: #e2e8f0;
     box-shadow: none;
   }
 
   .about-podium__item--pending .about-podium__name {
     color: #6b7280;
     font-weight: 600;
+  }
+
+  .about-charity {
+    margin: 0 24px 24px;
+    padding: 14px 16px;
+    border-radius: 12px;
+    background: #f8fafc;
+    border: 1px dashed #cbd5e1;
+    color: #4b5563;
+  }
+
+  .about-charity__title {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 700;
+    color: #284b63;
+    margin-bottom: 8px;
+  }
+
+  .about-charity__text {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.5;
   }
 
   @media (max-width: 576px) {
@@ -352,8 +398,25 @@
       font-size: 1.5rem;
     }
 
-    .about-card .card-img-top {
-      height: 180px;
+    .about-card__image {
+      height: 200px;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .about-card__layout {
+      flex-direction: row;
+    }
+
+    .about-card__media {
+      flex: 0 0 38%;
+      max-width: 38%;
+      border-right: 1px solid #e2e8f0;
+    }
+
+    .about-card__image {
+      height: 100%;
+      min-height: 260px;
     }
   }
   


### PR DESCRIPTION
### Motivation
- Convert the About timeline into a clearer horizontal card layout with media on the left and text/insights/charity on the right to better surface images and winners. 
- Surface winners/labels under the main image and provide a placeholder for charity information. 
- Replace the existing purple accent with the requested `#284b63` to refresh the page palette.

### Description
- Reworked `about.php` to replace the grid of vertical cards with full-width horizontal cards using new markup (`about-card--horizontal`, `about-card__layout`, `about-card__media`, `about-card__content`, `about-card__image`) and moved podium items under each image. 
- Added a `about-charity` block as a placeholder for charity details and kept the existing descriptive text and pros/cons lists on the right. 
- Updated `css/styles.css` to support the new horizontal layout and responsive behavior, including hero gradient tweaks, new layout classes, podium styling changes, and charity placeholder styles. 
- Replaced purple accent usages (kicker, readmore link, podium gradient) with `#284b63` and adjusted related backgrounds/borders for consistent contrast.

### Testing
- Started a local PHP dev server with `php -S 0.0.0.0:8000 -t /workspace/hendys-hunches` and the server started successfully. 
- Ran a Playwright script to load `http://127.0.0.1:8000/about.php` and capture a screenshot (`artifacts/about-page.png`), which completed successfully. 
- No additional automated unit tests were added or run for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b9a5a39a48324bac5d7363dc5150d)